### PR TITLE
Add apiKey parameter to OpenAI-compatible model types

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,8 +700,6 @@ The `text-embedding-3-small` is a new standard embedding model released by OpenA
 - To use an API key other than the one set in OPENAI_API_KEY (e.g., to use different OpenAI-compatible embedding and 
 generation services)
 
-
-
 ```TS
 
 const ragApplication = await new RAGApplicationBuilder()

--- a/README.md
+++ b/README.md
@@ -488,6 +488,13 @@ const ragApplication = await new RAGApplicationBuilder()
 .setModel(new OpenAi({ modelName: 'gpt-4' }))
 ```
 
+- To use an API key other than the one set in OPENAI_API_KEY (e.g., to use different OpenAI-compatible embedding and generation services)
+
+```TS
+const ragApplication = await new RAGApplicationBuilder()
+.setModel(new OpenAi({ modelName: 'gpt-4', apiKey: "<Your key>" }))
+```
+
 -   To use a custom model name and a custom base URL for an OpenAI-compatible API
 
 ```TS
@@ -540,7 +547,7 @@ const ragApplication = await new RAGApplicationBuilder()
     temperature: 0.2, // or whatever temperature you'd like
     maxNewTokens: 128, // or however many max tokens you'd like 
 }) )
-    ```
+```
 
 ## Mistral
 
@@ -690,6 +697,17 @@ The library supports the following embedding models -
 
 The `text-embedding-3-small` is a new standard embedding model released by OpenAI in Jan, 2024. It is the default used by the libary. This model is cheaper and better than their older Ada model. This model returns vectors with dimension 1536.
 
+- To use an API key other than the one set in OPENAI_API_KEY (e.g., to use different OpenAI-compatible embedding and 
+generation services)
+
+
+
+```TS
+
+const ragApplication = await new RAGApplicationBuilder()
+.setEmbeddingModel(new OpenAi3SmallEmbeddings({ apiKey: "<Your key>" }))
+```
+
 You do not have to do anything to enable it.
 
 ## OpenAI v3 Large
@@ -707,6 +725,13 @@ await new RAGApplicationBuilder()
 .setEmbeddingModel(new OpenAi3LargeEmbeddings())
 ```
 
+-  To use an API key other than the one set in OPENAI_API_KEY (e.g., to use different OpenAI-compatible embedding and generation services)
+
+```TS
+const ragApplication = await new RAGApplicationBuilder()
+.setEmbeddingModel(new OpenAi3LargeEmbeddings({ apiKey: "<Your key>" }))
+```
+
 ## OpenAI Generic
 
 To support OpenAI-compatible API implementations with arbitrary embedding models, use the OpenAIGenericEmbeddings model, which allows you to specify a model name, base URL, and the dimensions of the returned vectors.
@@ -720,6 +745,15 @@ import { OpenAIGenericEmbeddings } from '@llm-tools/embedjs';
 
 await new RAGApplicationBuilder()
 .setEmbeddingModel(new OpenAIGenericEmbeddings({ modelName: '[YOUR_EMBEDDING_MODEL_NAME]', baseURL: '[YOUR_BASE_URL]', dimensions: YOUR_VECTOR_SIZE }))
+```
+
+-  To use an API key other than the one set in OPENAI_API_KEY (e.g., to use different OpenAI-compatible embedding and generation services)
+
+```TS
+import { OpenAIGenericEmbeddings } from '@llm-tools/embedjs';
+
+await new RAGApplicationBuilder()
+.setEmbeddingModel(new OpenAIGenericEmbeddings({ modelName: '[YOUR_EMBEDDING_MODEL_NAME]', baseURL: '[YOUR_BASE_URL]', apiKey: "<Your key>", dimensions: YOUR_VECTOR_SIZE }))
 ```
 
 ## Ada

--- a/src/embeddings/ada-embeddings.ts
+++ b/src/embeddings/ada-embeddings.ts
@@ -4,8 +4,8 @@ import { BaseEmbeddings } from '../interfaces/base-embeddings.js';
 export class AdaEmbeddings implements BaseEmbeddings {
     private model: OpenAIEmbeddings;
 
-    constructor() {
-        this.model = new OpenAIEmbeddings({ modelName: 'text-embedding-ada-002', maxConcurrency: 3, maxRetries: 5 });
+    constructor( params? : { apiKey?: string}) {
+        this.model = new OpenAIEmbeddings({ modelName: 'text-embedding-ada-002', maxConcurrency: 3, maxRetries: 5, apiKey: params?.apiKey ?? undefined });
     }
 
     getDimensions(): number {

--- a/src/embeddings/openai-3large-embeddings.ts
+++ b/src/embeddings/openai-3large-embeddings.ts
@@ -5,7 +5,7 @@ export class OpenAi3LargeEmbeddings implements BaseEmbeddings {
     private model: OpenAIEmbeddings;
     private readonly dynamicDimension: number;
 
-    constructor(params?: { dynamicDimension?: number }) {
+    constructor(params?: { apiKey?: string, dynamicDimension?: number }) {
         this.dynamicDimension = params?.dynamicDimension ?? 3072;
 
         this.model = new OpenAIEmbeddings({
@@ -13,6 +13,7 @@ export class OpenAi3LargeEmbeddings implements BaseEmbeddings {
             maxConcurrency: 3,
             maxRetries: 5,
             dimensions: this.dynamicDimension,
+            apiKey: params?.apiKey ?? undefined
         });
     }
 

--- a/src/embeddings/openai-generic-embeddings.ts
+++ b/src/embeddings/openai-generic-embeddings.ts
@@ -12,8 +12,8 @@ export class OpenAiGenericEmbeddings implements BaseEmbeddings {
     private model: OpenAIEmbeddings;
     private readonly dimensions: number;
 
-    constructor({ modelName, baseURL, dimensions} : { modelName: string, baseURL : string, dimensions: number}) {
-        this.model = new OpenAIEmbeddings({ modelName: modelName, maxConcurrency: 3, maxRetries: 5 }, { baseURL: baseURL});
+    constructor({ modelName, baseURL, apiKey, dimensions} : { modelName: string, baseURL : string, apiKey?: string, dimensions: number}) {
+        this.model = new OpenAIEmbeddings({ modelName: modelName, maxConcurrency: 3, maxRetries: 5, apiKey: apiKey ?? undefined }, { baseURL: baseURL});
         this.dimensions = dimensions;
     }
 

--- a/src/models/openai-model.ts
+++ b/src/models/openai-model.ts
@@ -9,18 +9,20 @@ export class OpenAi extends BaseModel {
     private readonly debug = createDebugMessages('embedjs:model:OpenAi');
     private readonly modelName: string;
     private readonly baseURL: string;
+    private readonly apiKey: string;
     private model: ChatOpenAI;
 
-    constructor({ temperature, modelName, baseURL }: { temperature?: number; modelName: string, baseURL?: string }) {
+    constructor({ temperature, modelName, baseURL, apiKey }: { temperature?: number; modelName: string, baseURL?: string, apiKey? : string }) {
         super(temperature);
         this.modelName = modelName;
         if (baseURL !== undefined) {
             this.baseURL = baseURL;
         }
+        this.apiKey = apiKey ?? undefined
     }
 
     override async init(): Promise<void> {
-        this.model = new ChatOpenAI({ temperature: this.temperature, model: this.modelName }, this.baseURL ? { baseURL: this.baseURL } : {});
+        this.model = new ChatOpenAI({ temperature: this.temperature, model: this.modelName, apiKey : this.apiKey }, this.baseURL ? { baseURL: this.baseURL } : {});
     }
 
     override async runQuery(


### PR DESCRIPTION
Reduces dependence on environment variables. 

Azure OpenAI models still need to be configured via env vars