### PR TITLE
added embedding classes with dynamic API key and model name support for multiple providers 

### DIFF
--- a/src/embeddings/cohere-embeddings.ts
+++ b/src/embeddings/cohere-embeddings.ts
@@ -5,9 +5,10 @@ import { BaseEmbeddings } from '../interfaces/base-embeddings.js';
 export class CohereEmbeddings implements BaseEmbeddings {
     private model: LangChainCohereEmbeddings;
 
-    constructor() {
+    constructor(apiKey: string, modelName: string) {
         this.model = new LangChainCohereEmbeddings({
-            model: 'embed-english-v2.0',
+            model: modelName ?? 'embed-english-v2.0',
+            apiKey: apiKey, 
             maxConcurrency: 3,
             maxRetries: 5,
         });

--- a/src/models/anthropic-model.ts
+++ b/src/models/anthropic-model.ts
@@ -8,15 +8,20 @@ import { Chunk, Message } from '../global/types.js';
 export class Anthropic extends BaseModel {
     private readonly debug = createDebugMessages('embedjs:model:Anthropic');
     private readonly modelName: string;
+    private readonly apiKey: string;
+    private readonly baseURL: string;
     private model: ChatAnthropic;
 
-    constructor(params?: { temperature?: number; modelName?: string }) {
+    constructor(params?: { temperature?: number; modelName?: string; apiKey?: string; baseURL?: string }) {
         super(params?.temperature);
         this.modelName = params?.modelName ?? 'claude-3-sonnet-20240229';
+        this.apiKey = params?.apiKey;
+        this.baseURL = params?.baseURL;
     }
 
+    
     override async init(): Promise<void> {
-        this.model = new ChatAnthropic({ temperature: this.temperature, model: this.modelName });
+        this.model = new ChatAnthropic({ temperature: this.temperature, model: this.modelName, anthropicApiKey: this.apiKey, anthropicApiUrl: this.baseURL });
     }
 
     override async runQuery(
@@ -47,3 +52,4 @@ export class Anthropic extends BaseModel {
         return result.content.toString();
     }
 }
+

--- a/src/models/huggingface-model.ts
+++ b/src/models/huggingface-model.ts
@@ -10,12 +10,14 @@ export class HuggingFace extends BaseModel {
     private readonly modelName: string;
     private readonly maxNewTokens: number;
     private readonly endpointUrl?: string;
+    private readonly apiKey?: string;
     private model: HuggingFaceInference;
 
-    constructor(params?: { modelName?: string; temperature?: number; maxNewTokens?: number; endpointUrl?: string }) {
+    constructor(params?: { modelName?: string; temperature?: number; maxNewTokens?: number; endpointUrl?: string, apiKey?: string }) {
         super(params?.temperature);
 
         this.endpointUrl = params?.endpointUrl;
+        this.apiKey = params?.apiKey;
         this.maxNewTokens = params?.maxNewTokens ?? 300;
         this.modelName = params?.modelName ?? 'mistralai/Mixtral-8x7B-Instruct-v0.1';
     }
@@ -23,6 +25,7 @@ export class HuggingFace extends BaseModel {
     override async init(): Promise<void> {
         this.model = new HuggingFaceInference({
             model: this.modelName,
+            apiKey: this.apiKey,
             maxTokens: this.maxNewTokens,
             temperature: this.temperature,
             endpointUrl: this.endpointUrl,

--- a/src/models/mistral-model.ts
+++ b/src/models/mistral-model.ts
@@ -11,15 +11,18 @@ export class Mistral extends BaseModel {
 
     constructor({
         temperature,
-        accessToken,
+        // accessToken,
         modelName,
+        apiKey,
+        endpoint,
     }: {
         temperature?: number;
-        accessToken: string;
+        apiKey: string;
         modelName?: string;
+        endpoint?: string;
     }) {
         super(temperature);
-        this.model = new ChatMistralAI({ apiKey: accessToken, model: modelName ?? 'mistral-medium' });
+        this.model = new ChatMistralAI({ apiKey: apiKey, model: modelName ?? 'mistral-medium', endpoint: endpoint });
     }
 
     override async runQuery(


### PR DESCRIPTION
Updated HuggingFace, Mistral, Cohere, and Anthropic embeddings constructors to accept `apiKey` and `modelName` as parameters.

**Aisling** Please review this